### PR TITLE
Make Decimal inputs work

### DIFF
--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -62,7 +62,6 @@ def _to_numeric(arg):
     Convert a string or other value  into float, integer or long.
     Convert float value to integer if appropriate.
     """
-    print(f'to numeric {arg} {type(arg)}')
     if _is_string(arg) and '.' in arg:
         arg = float(arg)
     if isinstance(arg, float):

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -5,6 +5,7 @@ https://github.com/jwadhams/json-logic-js
 
 # Python 2 fallbacks
 from __future__ import division, unicode_literals
+from decimal import Decimal
 
 from six import advance_iterator, integer_types, text_type
 from six.moves import reduce
@@ -61,10 +62,13 @@ def _to_numeric(arg):
     Convert a string or other value  into float, integer or long.
     Convert float value to integer if appropriate.
     """
+    print(f'to numeric {arg} {type(arg)}')
     if _is_string(arg) and '.' in arg:
         arg = float(arg)
     if isinstance(arg, float):
         return int(arg) if arg.is_integer() else arg
+    if isinstance(arg, Decimal):
+        return int(arg) if arg == int(arg) else float(arg)
     return int(arg)
 
 

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import datetime
+from decimal import Decimal
 import json
 import logging
 import unittest
@@ -182,6 +183,10 @@ class AdditionalJsonLogicTests(unittest.TestCase):
         self.assertIs(jsonLogic({'===': [1, 1]}), True)
         self.assertIs(jsonLogic({'===': [1.23, 1.23]}), True)
         self.assertIs(jsonLogic({'===': [1, 1.0]}), True)
+        self.assertIs(jsonLogic({'===': [1, Decimal(1)]}), False)
+        self.assertIs(jsonLogic({'===': [1, Decimal(1.0)]}), False)
+        self.assertIs(jsonLogic({'==': [1, Decimal(1)]}), True)
+        self.assertIs(jsonLogic({'==': [1, Decimal(1.0)]}), True)
         self.assertIs(
             jsonLogic({'===': [10000000000000000000, 10000000000000000000.0]}),
             True)
@@ -189,6 +194,8 @@ class AdditionalJsonLogicTests(unittest.TestCase):
     def test_less_then_type_coercion_peculiarities(self):
         self.assertIs(jsonLogic({'<': ["11", 2, "3"]}), False)
         self.assertIs(jsonLogic({'<': ["11", "2", 3]}), True)
+        self.assertIs(jsonLogic({'<': [Decimal(3.001), 3]}), False)
+        self.assertIs(jsonLogic({'>': [Decimal(3.001), 3]}), True)
 
     def test_less_then_or_equal_to_type_coercion_peculiarities(self):
         self.assertIs(jsonLogic({'<=': ["11", 2, "3"]}), False)


### PR DESCRIPTION
We are using json logic with `Decimals` here and there. As a workaround we are currently converting them to `float` before the calculation, but it would be nicer if `to_numeric` would regognize them.